### PR TITLE
Vaihdettu "valintalaskentakerralla"-pyynnöt menemään valintalaskenta--servicen kautta

### DIFF
--- a/src/app/lib/configuration.ts
+++ b/src/app/lib/configuration.ts
@@ -34,6 +34,7 @@ export const configuration = {
   ataruEditoriLogin: `${DOMAIN}/lomake-editori/auth/cas`,
   valintalaskentaServiceLogin: `${DOMAIN}/valintalaskenta-laskenta-service/auth/login`,
   valintalaskentaKoostePalveluUrl: `${DOMAIN}/valintalaskentakoostepalvelu/resources/`,
+  valintalaskentaServiceUrl: `${DOMAIN}/valintalaskenta-laskenta-service/resources/`,
   koostetutPistetiedot: ({
     hakuOid,
     hakukohdeOid,

--- a/src/app/lib/valintalaskentakoostepalvelu.ts
+++ b/src/app/lib/valintalaskentakoostepalvelu.ts
@@ -87,7 +87,7 @@ export const kaynnistaLaskenta = async (
 ): Promise<LaskentaStart> => {
   const laskentaUrl = formSearchParamsForStartLaskenta({
     laskentaUrl: new URL(
-      `${configuration.valintalaskentaKoostePalveluUrl}valintalaskentakerralla/haku/${haku.oid}/tyyppi/HAKUKOHDE/whitelist/true?`,
+      `${configuration.valintalaskentaServiceUrl}valintalaskentakerralla/haku/${haku.oid}/tyyppi/HAKUKOHDE/whitelist/true?`,
     ),
     haku,
     hakukohde,
@@ -114,7 +114,7 @@ export const kaynnistaLaskentaHakukohteenValinnanvaiheille = async (
 ): Promise<LaskentaStart> => {
   const laskentaUrl = formSearchParamsForStartLaskenta({
     laskentaUrl: new URL(
-      `${configuration.valintalaskentaKoostePalveluUrl}valintalaskentakerralla/haku/${haku.oid}/tyyppi/HAKUKOHDE/whitelist/true?`,
+      `${configuration.valintalaskentaServiceUrl}valintalaskentakerralla/haku/${haku.oid}/tyyppi/HAKUKOHDE/whitelist/true?`,
     ),
     haku,
     hakukohde,
@@ -140,7 +140,7 @@ export const getLaskennanTilaHakukohteelle = async (
       ilmoitukset: [{ otsikko: string; tyyppi: string }] | null;
     }>;
   }>(
-    `${configuration.valintalaskentaKoostePalveluUrl}valintalaskentakerralla/status/${loadingUrl}/yhteenveto`,
+    `${configuration.valintalaskentaServiceUrl}valintalaskentakerralla/status/${loadingUrl}/yhteenveto`,
   );
   return response.data?.hakukohteet
     ?.filter((hk) => hk.ilmoitukset?.some((i) => i.tyyppi === 'VIRHE'))

--- a/tests/e2e/valinnan-hallinta.spec.ts
+++ b/tests/e2e/valinnan-hallinta.spec.ts
@@ -33,7 +33,7 @@ test('displays valinnanvaiheet', async ({ page }) => {
 
 test('starts laskenta', async ({ page }) => {
   await page.route(
-    '*/**/valintalaskentakoostepalvelu/resources/valintalaskentakerralla/haku/1.2.246.562.29.00000000000000045102/tyyppi/HAKUKOHDE/whitelist/true**',
+    '*/**/resources/valintalaskentakerralla/haku/1.2.246.562.29.00000000000000045102/tyyppi/HAKUKOHDE/whitelist/true**',
     async (route) => {
       const started = {
         lisatiedot: {
@@ -70,7 +70,7 @@ test('starts laskenta', async ({ page }) => {
 
 test('shows success toast when laskenta completes', async ({ page }) => {
   await page.route(
-    '*/**/valintalaskentakoostepalvelu/resources/valintalaskentakerralla/haku/1.2.246.562.29.00000000000000045102/tyyppi/HAKUKOHDE/whitelist/true**',
+    '*/**/resources/valintalaskentakerralla/haku/1.2.246.562.29.00000000000000045102/tyyppi/HAKUKOHDE/whitelist/true**',
     async (route) => {
       const started = {
         lisatiedot: {
@@ -98,7 +98,7 @@ test('shows success toast when laskenta completes', async ({ page }) => {
     },
   );
   await page.route(
-    '*/**/valintalaskentakoostepalvelu/resources/valintalaskentakerralla/status/12345abs/yhteenveto',
+    '*/**/resources/valintalaskentakerralla/status/12345abs/yhteenveto',
     async (route) => {
       await route.fulfill({
         json: {
@@ -124,7 +124,7 @@ test('shows success toast when laskenta completes', async ({ page }) => {
 
 test('starting laskenta causes error', async ({ page }) => {
   await page.route(
-    '*/**/valintalaskentakoostepalvelu/resources/valintalaskentakerralla/haku/1.2.246.562.29.00000000000000045102/tyyppi/HAKUKOHDE/whitelist/true**',
+    '*/**/resources/valintalaskentakerralla/haku/1.2.246.562.29.00000000000000045102/tyyppi/HAKUKOHDE/whitelist/true**',
     async (route) => {
       await route.fulfill({ status: 500, body: 'Unknown error' });
     },


### PR DESCRIPTION
"valintalaskentakerralla"-rajapinnat on muutettu toimimaan valintalaskenta-servicen kautta valintalaskentakoostepalvelun sijaan tiketillä OK-611. Vaihdetaan kutsut menemään valintalaskenta-servicen kautta. Vastaava muutos vanhaan käyttöliittymäään haarassa: https://github.com/Opetushallitus/valintalaskenta-ui/tree/OK-611_laskennan_rinnakkaistaminen