### PR TITLE
OK-580: Korjattu hyväksymiskirjeiden muodostaminen

### DIFF
--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -94,6 +94,7 @@ const RESPONSE_BODY_PARSERS: Record<string, BodyParser<unknown>> = {
   'application/vnd.ms-excel': BLOB_PARSER,
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
     BLOB_PARSER,
+  'binary/octet-stream': BLOB_PARSER,
   'text/plain': TEXT_PARSER,
 };
 


### PR DESCRIPTION
Hyväksymiskirjeiden content-type oli vaihtunut "binary/octet-stream"-tyyppiseksi. Parsitaan vastauksen sisältö blobiksi myös tälle content-typelle.

Oletko lisännyt tarvittavat yksikkö- tai ui-testit toiminnallisuudelle? En
Oletko tarkistanut ja päivittänyt riippuvuudet? En
Oletko kokeillut toimiiko käyttöliittymä mobiilissa landscape moodissa? Ei koske
Oletko testannut että lisäämäsi toiminto on saavutettava? Ei koske
