### PR TITLE
Luetaan nextjs cache policy id parameter storesta valueFromLookup-fun…

### DIFF
--- a/cdk/.gitignore
+++ b/cdk/.gitignore
@@ -1,2 +1,3 @@
 bin/*.js
 lib/*.js
+cdk.context.json

--- a/cdk/lib/sovellus-stack.ts
+++ b/cdk/lib/sovellus-stack.ts
@@ -72,12 +72,10 @@ export class SovellusStack extends cdk.Stack {
   ) {
     super(scope, id, props);
 
-    const OPEN_NEXT_SERVER_CACHE_POLICY_ID =
-      StringParameter.fromStringParameterAttributes(
-        this,
-        'serverCachePolicyId',
-        { parameterName: '/dev/NextJs/serverCachePolicyId' },
-      ).stringValue;
+    const OPEN_NEXT_SERVER_CACHE_POLICY_ID = StringParameter.valueFromLookup(
+      this,
+      '/dev/NextJs/serverCachePolicyId',
+    );
 
     const hostedZone = route53.HostedZone.fromHostedZoneAttributes(
       this,


### PR DESCRIPTION
…ktiolla

Aiempi toteutus ei päivittänyt parametria ensimmäisen kerran jälkeen, vaan yritti aina noutaa vanhalla nimellä, koska ilmeisesti se ei muuttanut cloudformation-stackkia, eikä CDK:n mukaan tehtäviä muutoksia ollut. Uusi toteutus luo myös cdk.context.json-tiedoston, joka on lisätty gitignoreen.

