### PR TITLE
OK-968: Poistettu usesLaskentaOrSijoittelu-funktion käyttö

### DIFF
--- a/cdk/lib/sovellus-stack.ts
+++ b/cdk/lib/sovellus-stack.ts
@@ -134,6 +134,7 @@ export class SovellusStack extends cdk.Stack {
           },
           distributionProps: {
             priceClass: PriceClass.PRICE_CLASS_100,
+            enableIpv6: false,
           },
         },
         ...nameOverrides(

--- a/src/lib/hakukohde-tab-utils.test.ts
+++ b/src/lib/hakukohde-tab-utils.test.ts
@@ -134,69 +134,46 @@ describe('getVisibleTabs', () => {
     ]);
   });
 
-  test.each([
-    { hakutapa: 'hakutapa_02' },
-    { hakutapa: 'hakutapa_03' },
-    { hakutapa: 'hakutapa_04' },
-    { hakutapa: 'hakutapa_05' },
-    { hakutapa: 'hakutapa_06' },
-  ])(
-    'returns right tabs for korkeakoulutus with "$hakutapa" without sijoittelu and without valintalaskenta',
-    async ({ hakutapa }: { hakutapa: string }) => {
-      const tabs = getVisibleTabs({
-        haku: {
-          ...HAKU_BASE,
-          kohdejoukkoKoodiUri: 'haunkohdejoukko_12#1', // Korkeakoulutus
-          hakutapaKoodiUri: `${hakutapa}#1`,
-        },
-        hakukohde: HAKUKOHDE_BASE,
-        haunAsetukset: { sijoittelu: false },
-        usesValintalaskenta: false,
-        permissions: OPH_PERMISSIONS,
-      });
-      expect(tabs.map((t) => t.route)).toEqual([
-        'perustiedot',
-        'hakeneet',
-        'valinnan-hallinta',
-        'valintakoekutsut',
-        'pistesyotto',
-        'valinnan-tulokset',
-      ]);
-    },
-  );
+  test('returns right tabs for korkeakoulutus without sijoittelu and without valintalaskenta', () => {
+    const tabs = getVisibleTabs({
+      haku: {
+        ...HAKU_BASE,
+        kohdejoukkoKoodiUri: 'haunkohdejoukko_12#1', // Korkeakoulutus
+      },
+      hakukohde: HAKUKOHDE_BASE,
+      haunAsetukset: { sijoittelu: false },
+      usesValintalaskenta: false,
+      permissions: OPH_PERMISSIONS,
+    });
+    expect(tabs.map((t) => t.route)).toEqual([
+      'perustiedot',
+      'hakeneet',
+      'valinnan-tulokset',
+    ]);
+  });
 
-  test.each([
-    { hakutapa: 'hakutapa_02' },
-    { hakutapa: 'hakutapa_03' },
-    { hakutapa: 'hakutapa_04' },
-    { hakutapa: 'hakutapa_05' },
-    { hakutapa: 'hakutapa_06' },
-  ])(
-    'returns right tabs for korkeakoulutus with "$hakutapa" without sijoittelu and with valintalaskenta',
-    async ({ hakutapa }: { hakutapa: string }) => {
-      const tabs = getVisibleTabs({
-        haku: {
-          ...HAKU_BASE,
-          kohdejoukkoKoodiUri: 'haunkohdejoukko_12#1', // Korkeakoulutus
-          hakutapaKoodiUri: `${hakutapa}#1`,
-        },
-        hakukohde: HAKUKOHDE_BASE,
-        haunAsetukset: { sijoittelu: false },
-        usesValintalaskenta: true,
-        permissions: OPH_PERMISSIONS,
-      });
-      expect(tabs.map((t) => t.route)).toEqual([
-        'perustiedot',
-        'hakeneet',
-        'valinnan-hallinta',
-        'valintakoekutsut',
-        'pistesyotto',
-        'hakijaryhmat',
-        'valintalaskennan-tulokset',
-        'sijoittelun-tulokset',
-      ]);
-    },
-  );
+  test('returns right tabs for korkeakoulutus without sijoittelu and with valintalaskenta', async () => {
+    const tabs = getVisibleTabs({
+      haku: {
+        ...HAKU_BASE,
+        kohdejoukkoKoodiUri: 'haunkohdejoukko_12#1', // Korkeakoulutus
+      },
+      hakukohde: HAKUKOHDE_BASE,
+      haunAsetukset: { sijoittelu: false },
+      usesValintalaskenta: true,
+      permissions: OPH_PERMISSIONS,
+    });
+    expect(tabs.map((t) => t.route)).toEqual([
+      'perustiedot',
+      'hakeneet',
+      'valinnan-hallinta',
+      'valintakoekutsut',
+      'pistesyotto',
+      'hakijaryhmat',
+      'valintalaskennan-tulokset',
+      'sijoittelun-tulokset',
+    ]);
+  });
 
   test('only show perustiedot-tab, if no OPH permissions and use of valinnat disallowed via ohjausparametrit', async () => {
     const tabs = getVisibleTabs({

--- a/src/lib/hakukohde-tab-utils.ts
+++ b/src/lib/hakukohde-tab-utils.ts
@@ -1,7 +1,6 @@
 import {
   isHarkinnanvarainenHakukohde,
   isKorkeakouluHaku,
-  usesLaskentaOrSijoittelu,
 } from '@/lib/kouta/kouta-service';
 import { HaunAsetukset } from '@/lib/ohjausparametrit/ohjausparametrit-types';
 import { UserPermissions } from '@/lib/permissions';
@@ -47,27 +46,37 @@ export const TABS: Array<BasicTab> = [
   {
     title: 'valinnanhallinta.otsikko',
     route: 'valinnan-hallinta',
-    visibleFn: ({ haunAsetukset, permissions }) =>
+    visibleFn: ({ haunAsetukset, permissions, usesValintalaskenta }) =>
+      (haunAsetukset.sijoittelu || usesValintalaskenta) &&
       isAllowedToUseValinnat(haunAsetukset, permissions),
   },
   {
     title: 'valintakoekutsut.otsikko',
     route: 'valintakoekutsut',
-    visibleFn: ({ haunAsetukset, permissions }) =>
+    visibleFn: ({ haunAsetukset, permissions, usesValintalaskenta }) =>
+      (haunAsetukset.sijoittelu || usesValintalaskenta) &&
       isAllowedToUseValinnat(haunAsetukset, permissions),
   },
   {
     title: 'pistesyotto.otsikko',
     route: 'pistesyotto',
-    visibleFn: ({ haunAsetukset, permissions }) =>
+    visibleFn: ({ haunAsetukset, permissions, usesValintalaskenta }) =>
+      (haunAsetukset.sijoittelu || usesValintalaskenta) &&
       isAllowedToUseValinnat(haunAsetukset, permissions),
   },
   {
     title: 'harkinnanvaraiset.otsikko',
     route: 'harkinnanvaraiset',
-    visibleFn: ({ haku, hakukohde, haunAsetukset, permissions }) =>
+    visibleFn: ({
+      haku,
+      hakukohde,
+      haunAsetukset,
+      permissions,
+      usesValintalaskenta,
+    }) =>
       !isKorkeakouluHaku(haku) &&
       isHarkinnanvarainenHakukohde(hakukohde) &&
+      (haunAsetukset.sijoittelu || usesValintalaskenta) &&
       isAllowedToUseValinnat(haunAsetukset, permissions),
   },
   {
@@ -75,44 +84,29 @@ export const TABS: Array<BasicTab> = [
     route: 'hakijaryhmat',
     visibleFn: ({ haku, haunAsetukset, usesValintalaskenta, permissions }) =>
       isKorkeakouluHaku(haku) &&
-      (usesLaskentaOrSijoittelu({
-        haku,
-        haunAsetukset,
-      }) ||
-        usesValintalaskenta) &&
+      (haunAsetukset.sijoittelu || usesValintalaskenta) &&
       isAllowedToUseValinnat(haunAsetukset, permissions),
   },
   {
     title: 'valintalaskennan-tulokset.otsikko',
     route: 'valintalaskennan-tulokset',
-    visibleFn: ({ haku, haunAsetukset, usesValintalaskenta, permissions }) =>
-      (usesLaskentaOrSijoittelu({
-        haku,
-        haunAsetukset,
-      }) ||
-        usesValintalaskenta) &&
+    visibleFn: ({ haunAsetukset, usesValintalaskenta, permissions }) =>
+      (haunAsetukset.sijoittelu || usesValintalaskenta) &&
       isAllowedToUseValinnat(haunAsetukset, permissions),
   },
   {
     title: 'sijoittelun-tulokset.otsikko',
     route: 'sijoittelun-tulokset',
-    visibleFn: ({ haku, haunAsetukset, usesValintalaskenta, permissions }) =>
-      (usesLaskentaOrSijoittelu({
-        haku,
-        haunAsetukset,
-      }) ||
-        usesValintalaskenta) &&
+    visibleFn: ({ haunAsetukset, usesValintalaskenta, permissions }) =>
+      (haunAsetukset.sijoittelu || usesValintalaskenta) &&
       isAllowedToUseValinnat(haunAsetukset, permissions),
   },
   {
     title: 'valinnan-tulokset.otsikko',
     route: 'valinnan-tulokset',
-    visibleFn: ({ haku, haunAsetukset, usesValintalaskenta, permissions }) =>
-      !usesLaskentaOrSijoittelu({
-        haku,
-        haunAsetukset,
-      }) &&
+    visibleFn: ({ haunAsetukset, usesValintalaskenta, permissions }) =>
       !usesValintalaskenta &&
+      !haunAsetukset.sijoittelu &&
       isAllowedToUseValinnat(haunAsetukset, permissions),
   },
 ] as const;

--- a/src/lib/kouta/kouta-service.ts
+++ b/src/lib/kouta/kouta-service.ts
@@ -5,9 +5,8 @@ import { client } from '../http-client';
 import { Language, TranslatedName } from '../localization/localization-types';
 import { UserPermissions } from '../permissions';
 import { addProp, pick, pipe } from 'remeda';
-import { HaunAsetukset } from '../ohjausparametrit/ohjausparametrit-types';
 import { getConfiguration } from '@/lib/configuration/client-configuration';
-import { getConfigUrl } from '../configuration/configuration-utils';
+import { getConfigUrl } from '@/lib/configuration/configuration-utils';
 
 type HakuResponseData = {
   oid: string;
@@ -57,14 +56,6 @@ export async function getHaut(userPermissions: UserPermissions) {
 
 export const isYhteishaku = (haku: Haku): boolean =>
   haku.hakutapaKoodiUri.startsWith('hakutapa_01');
-
-export const usesLaskentaOrSijoittelu = ({
-  haku,
-  haunAsetukset,
-}: {
-  haku: Haku;
-  haunAsetukset: HaunAsetukset;
-}) => isYhteishaku(haku) || haunAsetukset.sijoittelu;
 
 export function isToisenAsteenYhteisHaku(haku: Haku): boolean {
   return (


### PR DESCRIPTION
- Tarkistetaan valintaperusteista onko laskenta käytössä.
- Muutettu hakukohde-välilehtien piilotuslogiikkaa siten että haulle, jolla ei ole sijoittelua eikä valintalaskentaa näytetään vain perustiedot, hakeneet ja valinnan tulokset.
- Näytetään yhteisvalinnan hallinta välilehdellä sijoittelu-osio silloin kun haun asetuksissa on sijoittelu päällä.

Oletko lisännyt tarvittavat yksikkö- tai ui-testit toiminnallisuudelle? Kyllä
Oletko tarkistanut ja päivittänyt riippuvuudet? En
Oletko kokeillut toimiiko käyttöliittymä mobiilissa landscape moodissa? Ei koske
Oletko testannut että lisäämäsi toiminto on saavutettava? Ei koske
