### PR TITLE
OY-5606: Korjattu toisen asteen yhteishauan vastaanottotilat

### DIFF
--- a/changes.patch
+++ b/changes.patch
@@ -1,0 +1,348 @@
+diff --git a/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tilat-edit-modal.tsx b/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tilat-edit-modal.tsx
+index 859cb293..4a9b80d8 100644
+--- a/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tilat-edit-modal.tsx
++++ b/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tilat-edit-modal.tsx
+@@ -32,7 +32,7 @@ import { LocalizedSelect } from '@/components/localized-select';
+ import { Haku } from '@/lib/kouta/kouta-types';
+ import { useIlmoittautumisTilaOptions } from '@/hooks/useIlmoittautumisTilaOptions';
+ import {
+-  getVastaanottoTilaLabelKey,
++  getVastaanottoTilaLabel,
+   useVastaanottoTilaOptions,
+ } from '@/hooks/useVastaanottoTilaOptions';
+ import { useIsValintaesitysJulkaistavissa } from '@/hooks/useIsValintaesitysJulkaistavissa';
+@@ -235,12 +235,11 @@ export const ValinnanTilatEditModal = createModal<{
+               renderValue={
+                 !vastaanottoTilaIsSelectable && vastaanottoTila
+                   ? () =>
+-                      t(
+-                        getVastaanottoTilaLabelKey({
+-                          tila: vastaanottoTila as VastaanottoTila,
+-                          haku,
+-                        }),
+-                      )
++                      getVastaanottoTilaLabel({
++                        tila: vastaanottoTila as VastaanottoTila,
++                        haku,
++                        t,
++                      })
+                   : undefined
+               }
+               options={vastaanottoTilaOptions}
+diff --git a/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tulos-cells.tsx b/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tulos-cells.tsx
+index a309bf6c..996e7bb4 100644
+--- a/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tulos-cells.tsx
++++ b/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tulos-cells.tsx
+@@ -16,7 +16,7 @@ import { HenkilonHakukohdeTuloksilla } from '../lib/henkilo-page-types';
+ import { useHaku } from '@/lib/kouta/useHaku';
+ import { styled } from '@/lib/theme';
+ import { LaskennanValintatapajonoTulos } from '@/hooks/useEditableValintalaskennanTulokset';
+-import { getVastaanottoTilaLabelKey } from '@/hooks/useVastaanottoTilaOptions';
++import { getVastaanottoTilaLabel } from '@/hooks/useVastaanottoTilaOptions';
+ 
+ const ValintaTableCell = styled(MuiTableCell)({
+   verticalAlign: 'top',
+@@ -93,12 +93,11 @@ export const ValinnanTulosCells = ({
+           </ValintaTableCell>
+           <ValintaTableCell>
+             <div>
+-              {t(
+-                getVastaanottoTilaLabelKey({
+-                  tila: valinnanTulos.vastaanottotila,
+-                  haku,
+-                }),
+-              )}
++              {getVastaanottoTilaLabel({
++                tila: valinnanTulos.vastaanottotila,
++                haku,
++                t,
++              })}
+             </div>
+           </ValintaTableCell>
+           <ValintaTableCell>
+diff --git a/src/components/ValinnanTuloksetOtherActionsCell.tsx b/src/components/ValinnanTuloksetOtherActionsCell.tsx
+index 76e2b0e8..c8cb844f 100644
+--- a/src/components/ValinnanTuloksetOtherActionsCell.tsx
++++ b/src/components/ValinnanTuloksetOtherActionsCell.tsx
+@@ -64,6 +64,7 @@ export const ValinnanTuloksetOtherActionsCell = ({
+ 
+   const showChangeHistoryForHakemus = () => {
+     showModal(ChangeHistoryGlobalModal, {
++      haku,
+       hakemus: {
+         ...hakemus,
+         valintatapajonoOid: hakemus.valintatapajonoOid ?? valintatapajonoOid,
+diff --git a/src/components/VastaanottoTilaCell.tsx b/src/components/VastaanottoTilaCell.tsx
+index 893c77f0..c9cf654a 100644
+--- a/src/components/VastaanottoTilaCell.tsx
++++ b/src/components/VastaanottoTilaCell.tsx
+@@ -14,7 +14,7 @@ import {
+ } from '@/lib/sijoittelun-tulokset-utils';
+ import { Haku, Hakukohde } from '@/lib/kouta/kouta-types';
+ import {
+-  getVastaanottoTilaLabelKey,
++  getVastaanottoTilaLabel,
+   useVastaanottoTilaOptions,
+ } from '@/hooks/useVastaanottoTilaOptions';
+ import { useIsValintaesitysJulkaistavissa } from '@/hooks/useIsValintaesitysJulkaistavissa';
+@@ -58,7 +58,11 @@ const HakijanVastaanottoTilaSection = ({
+       <Typography>
+         {t('sijoittelun-tulokset.hakijalle-naytetaan')}
+         &nbsp;
+-        {t(getVastaanottoTilaLabelKey({ tila: hakijanVastaanottoTila, haku }))}
++        {getVastaanottoTilaLabel({
++          tila: hakijanVastaanottoTila,
++          haku,
++          t,
++        })}
+       </Typography>
+     );
+   }
+@@ -117,7 +121,7 @@ const ValinnanVastaanottoTila = ({
+         renderValue={
+           !vastaanottoTilaIsSelectable && vastaanottoTila
+             ? () =>
+-                t(getVastaanottoTilaLabelKey({ tila: vastaanottoTila, haku }))
++                getVastaanottoTilaLabel({ tila: vastaanottoTila, haku, t })
+             : undefined
+         }
+         onChange={updateVastaanottoTila}
+@@ -184,7 +188,7 @@ const SijoittelunVastaanottoTila = ({
+           renderValue={
+             !vastaanottoTilaIsSelectable && vastaanottoTila
+               ? () =>
+-                  t(getVastaanottoTilaLabelKey({ tila: vastaanottoTila, haku }))
++                  getVastaanottoTilaLabel({ tila: vastaanottoTila, haku, t })
+               : undefined
+           }
+           onChange={updateVastaanottoTila}
+diff --git a/src/components/modals/change-history-global-modal.test.tsx b/src/components/modals/change-history-global-modal.test.tsx
+index 884c1153..887198ed 100644
+--- a/src/components/modals/change-history-global-modal.test.tsx
++++ b/src/components/modals/change-history-global-modal.test.tsx
+@@ -1,6 +1,18 @@
+ import { render } from '@testing-library/react';
+ import { describe, it, expect } from 'vitest';
+ import { HistoryEvent } from './change-history-global-modal';
++import { Haku, Tila } from '@/lib/kouta/kouta-types';
++import { VastaanottoTila } from '@/lib/types/sijoittelu-types';
++
++const TOISEN_ASTEEN_YHTEISHAKU: Haku = {
++  oid: 'haku-oid',
++  nimi: { fi: 'Haku' },
++  tila: Tila.JULKAISTU,
++  hakutapaKoodiUri: 'hakutapa_01',
++  hakukohteita: 1,
++  kohdejoukkoKoodiUri: 'haunkohdejoukko_11#1',
++  organisaatioOid: 'organisaatio-oid',
++};
+ 
+ describe('HistoryEvent', () => {
+   it('renders tila change correctly', () => {
+@@ -44,4 +56,21 @@ describe('HistoryEvent', () => {
+         'Sähköposti lähetetty:',
+     );
+   });
++  it('renders toisen asteen vastaanottanut without sitovasti suffix', () => {
++    const VASTAANOTTOTILA_CHANGES = [
++      {
++        field: 'vastaanottotila',
++        to: VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
++      },
++    ];
++    const { container } = render(
++      <HistoryEvent
++        changes={VASTAANOTTOTILA_CHANGES}
++        haku={TOISEN_ASTEEN_YHTEISHAKU}
++      />,
++    );
++    expect(container).toHaveTextContent(
++      'sijoittelun-tulokset.muutoshistoria.muutokset.vastaanottotila: vastaanottotila.VASTAANOTTANUT',
++    );
++  });
+ });
+diff --git a/src/components/modals/change-history-global-modal.tsx b/src/components/modals/change-history-global-modal.tsx
+index 025734b0..e340d47c 100644
+--- a/src/components/modals/change-history-global-modal.tsx
++++ b/src/components/modals/change-history-global-modal.tsx
+@@ -25,20 +25,37 @@ import { toFormattedDateTimeString } from '@/lib/localization/translation-utils'
+ import { isTimestamp } from '@/lib/time-utils';
+ import { ErrorAlert } from '../error-alert';
+ import { queryOptionsGetChangeHistoryForHakemus } from '@/lib/valinta-tulos-service/valinta-tulos-queries';
++import { Haku } from '@/lib/kouta/kouta-types';
++import { getVastaanottoTilaLabel } from '@/hooks/useVastaanottoTilaOptions';
++import { VastaanottoTila } from '@/lib/types/sijoittelu-types';
+ 
+ export const HistoryEvent = ({
+   changes,
++  haku,
+ }: {
+   changes: Array<HakemusChangeDetail>;
++  haku?: Haku;
+ }) => {
+   const { t } = useTranslations();
+-  const parseMuutos = (muutos: string | boolean) => {
++  const parseMuutos = ({
++    field,
++    muutos,
++  }: {
++    field: string;
++    muutos: string | boolean;
++  }) => {
+     if (typeof muutos === 'boolean') {
+       return !muutos ? t('yleinen.ei') : t('yleinen.kylla');
+     } else if (isTimestamp(muutos)) {
+       return toFormattedDateTimeString(muutos);
+     } else if (isEmpty(muutos)) {
+       return '';
++    } else if (field === 'vastaanottotila') {
++      return getVastaanottoTilaLabel({
++        tila: muutos as VastaanottoTila,
++        haku,
++        t,
++      });
+     }
+ 
+     return t(`sijoittelun-tulokset.muutoshistoria.muutokset.${muutos}`, {
+@@ -58,7 +75,7 @@ export const HistoryEvent = ({
+ 
+   return changes.map((c, index) => (
+     <Box key={`change-detail-${index}`}>
+-      {parseKey(c.field)}: {parseMuutos(c.to)}
++      {parseKey(c.field)}: {parseMuutos({ field: c.field, muutos: c.to })}
+     </Box>
+   ));
+ };
+@@ -66,9 +83,11 @@ export const HistoryEvent = ({
+ const HistoryModalContent = ({
+   hakemusOid,
+   valintatapajonoOid,
++  haku,
+ }: {
+   hakemusOid: string;
+   valintatapajonoOid: string;
++  haku: Haku;
+ }) => {
+   const { data: history } = useSuspenseQuery(
+     queryOptionsGetChangeHistoryForHakemus({ hakemusOid, valintatapajonoOid }),
+@@ -93,7 +112,7 @@ const HistoryModalContent = ({
+     makeColumnWithCustomRender<HakemusChangeEvent>({
+       title: 'sijoittelun-tulokset.muutoshistoria.muutos',
+       key: 'changes',
+-      renderFn: (props) => <HistoryEvent changes={props.changes} />,
++      renderFn: (props) => <HistoryEvent changes={props.changes} haku={haku} />,
+       sortable: false,
+     }),
+   ];
+@@ -110,8 +129,10 @@ const HistoryModalContent = ({
+ 
+ export const ChangeHistoryGlobalModal = createModal(
+   ({
++    haku,
+     hakemus,
+   }: {
++    haku: Haku;
+     hakemus: {
+       hakemusOid: string;
+       hakijanNimi: string;
+@@ -148,6 +169,7 @@ export const ChangeHistoryGlobalModal = createModal(
+             <HistoryModalContent
+               hakemusOid={hakemus.hakemusOid}
+               valintatapajonoOid={hakemus.valintatapajonoOid}
++              haku={haku}
+             />
+           </QuerySuspenseBoundary>
+         )}
+diff --git a/src/hooks/useVastaanottoTilaOptions.test.ts b/src/hooks/useVastaanottoTilaOptions.test.ts
+index 9303c2fc..9f4448c7 100644
+--- a/src/hooks/useVastaanottoTilaOptions.test.ts
++++ b/src/hooks/useVastaanottoTilaOptions.test.ts
+@@ -2,9 +2,11 @@ import { describe, expect, test } from 'vitest';
+ import { Haku, Tila } from '@/lib/kouta/kouta-types';
+ import { VastaanottoTila } from '@/lib/types/sijoittelu-types';
+ import {
++  getVastaanottoTilaLabel,
+   getSelectableVastaanottoTilat,
+   getVastaanottoTilaLabelKey,
+ } from './useVastaanottoTilaOptions';
++import { TFunction } from '@/lib/localization/useTranslations';
+ 
+ const HAKU_BASE: Haku = {
+   oid: 'haku-oid',
+@@ -103,3 +105,19 @@ describe('getVastaanottoTilaLabelKey', () => {
+     ).toBe('vastaanottotila.VASTAANOTTANUT_SITOVASTI');
+   });
+ });
++
++describe('getVastaanottoTilaLabel', () => {
++  test('uses default value for toisen asteen vastaanottanut when localization key is missing', () => {
++    const t = ((_key: string, params?: { defaultValue?: string }) => {
++      return params?.defaultValue ?? _key;
++    }) as TFunction;
++
++    expect(
++      getVastaanottoTilaLabel({
++        tila: VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
++        haku: HAKU_BASE,
++        t,
++      }),
++    ).toBe('Vastaanottanut');
++  });
++});
+diff --git a/src/hooks/useVastaanottoTilaOptions.ts b/src/hooks/useVastaanottoTilaOptions.ts
+index da81e270..2f9cb76b 100644
+--- a/src/hooks/useVastaanottoTilaOptions.ts
++++ b/src/hooks/useVastaanottoTilaOptions.ts
+@@ -1,5 +1,8 @@
+ import { VastaanottoTila } from '../lib/types/sijoittelu-types';
+-import { useTranslations } from '../lib/localization/useTranslations';
++import {
++  TFunction,
++  useTranslations,
++} from '../lib/localization/useTranslations';
+ import { Haku } from '@/lib/kouta/kouta-types';
+ import {
+   isKorkeakouluHaku,
+@@ -68,6 +71,34 @@ export const getVastaanottoTilaLabelKey = ({
+     ? 'vastaanottotila.VASTAANOTTANUT'
+     : `vastaanottotila.${tila}`;
+ 
++const getVastaanottoTilaLabelDefaultValue = ({
++  tila,
++  haku,
++}: {
++  tila: VastaanottoTila;
++  haku?: Haku;
++}) =>
++  haku &&
++  isToisenAsteenYhteisHaku(haku) &&
++  tila === VastaanottoTila.VASTAANOTTANUT_SITOVASTI
++    ? 'Vastaanottanut'
++    : undefined;
++
++export const getVastaanottoTilaLabel = ({
++  tila,
++  haku,
++  t,
++}: {
++  tila: VastaanottoTila;
++  haku?: Haku;
++  t: TFunction;
++}) => {
++  const key = getVastaanottoTilaLabelKey({ tila, haku });
++  const defaultValue = getVastaanottoTilaLabelDefaultValue({ tila, haku });
++
++  return defaultValue ? t(key, { defaultValue }) : t(key);
++};
++
+ type UseVastaanottoTilaOptionsConfig = {
+   haku?: Haku;
+   isRekisterinpitaja?: boolean;
+@@ -92,6 +123,6 @@ export const useVastaanottoTilaOptions = (
+     .filter(filterFn)
+     .map((tila) => ({
+       value: tila as string,
+-      label: t(getVastaanottoTilaLabelKey({ tila, haku })),
++      label: getVastaanottoTilaLabel({ tila, haku, t }),
+     }));
+ };

--- a/src/app/haku/[oid]/hakukohde/[hakukohde]/sijoittelun-tulokset/components/sijoittelun-tulos-action-bar.tsx
+++ b/src/app/haku/[oid]/hakukohde/[hakukohde]/sijoittelun-tulokset/components/sijoittelun-tulos-action-bar.tsx
@@ -21,6 +21,8 @@ import {
   ValinnanTulosEventType,
   ValinnanTulosMassChangeParams,
 } from '@/lib/state/valinnanTuloksetMachineTypes';
+import { Haku } from '@/lib/kouta/kouta-types';
+import { useUserPermissions } from '@/hooks/useUserPermissions';
 
 const IlmoittautumisSelect = ({
   hakemukset,
@@ -58,19 +60,25 @@ const IlmoittautumisSelect = ({
 };
 
 const VastaanOttoSelect = ({
+  haku,
   hakemukset,
   selection,
   massStatusChangeForm,
 }: {
+  haku: Haku;
   hakemukset: Array<HakemuksenValinnanTulos>;
   selection: Set<string>;
   massStatusChangeForm: (changeParams: ValinnanTulosMassChangeParams) => void;
 }) => {
   const { t } = useTranslations();
+  const { hasOphCRUD } = useUserPermissions();
 
   const [value, setValue] = useState<string>('');
 
-  const vastaanottotilaOptions = useVastaanottoTilaOptions();
+  const vastaanottotilaOptions = useVastaanottoTilaOptions({
+    haku,
+    isRekisterinpitaja: hasOphCRUD,
+  });
 
   const massUpdateVastaanOtto = (event: SelectChangeEvent<string>) => {
     massStatusChangeForm({
@@ -97,11 +105,13 @@ const VastaanOttoSelect = ({
 };
 
 export const SijoittelunTuloksetActionBar = ({
+  haku,
   hakemukset,
   selection,
   resetSelection,
   actorRef,
 }: {
+  haku: Haku;
   hakemukset: Array<HakemuksenValinnanTulos>;
   actorRef: ValinnanTulosActorRef | SijoittelunTulosActorRef;
   selection: Set<string>;
@@ -137,6 +147,7 @@ export const SijoittelunTuloksetActionBar = ({
         }}
       >
         <VastaanOttoSelect
+          haku={haku}
           hakemukset={hakemukset}
           selection={selection}
           massStatusChangeForm={massStatusChangeForm}

--- a/src/app/haku/[oid]/hakukohde/[hakukohde]/sijoittelun-tulokset/components/sijoittelun-tulos-table.tsx
+++ b/src/app/haku/[oid]/hakukohde/[hakukohde]/sijoittelun-tulokset/components/sijoittelun-tulos-table.tsx
@@ -274,6 +274,7 @@ export const SijoittelunTulosTable = ({
     <>
       {!userHasOnlyReadPermission && (
         <SijoittelunTuloksetActionBar
+          haku={haku}
           hakemukset={contextHakemukset}
           selection={selection}
           resetSelection={resetSelection}

--- a/src/app/haku/[oid]/hakukohde/[hakukohde]/valinnan-tulokset/components/ValinnanTuloksetActionBar.tsx
+++ b/src/app/haku/[oid]/hakukohde/[hakukohde]/valinnan-tulokset/components/ValinnanTuloksetActionBar.tsx
@@ -23,6 +23,8 @@ import {
   ValinnanTulosEventType,
   ValinnanTulosMassChangeParams,
 } from '@/lib/state/valinnanTuloksetMachineTypes';
+import { Haku } from '@/lib/kouta/kouta-types';
+import { useUserPermissions } from '@/hooks/useUserPermissions';
 
 const ValinnanTilaDropdown = ({
   hakemukset,
@@ -101,17 +103,23 @@ const IlmoittautumisTilaDropdown = ({
 };
 
 const VastaanottoTilaDropdown = ({
+  haku,
   hakemukset,
   selection,
   massStatusChangeForm,
 }: {
+  haku: Haku;
   hakemukset: Array<HakemuksenValinnanTulos>;
   selection: Set<string>;
   massStatusChangeForm: (changeParams: ValinnanTulosMassChangeParams) => void;
 }) => {
   const { t } = useTranslations();
+  const { hasOphCRUD } = useUserPermissions();
 
-  const vastaanottotilaOptions = useVastaanottoTilaOptions();
+  const vastaanottotilaOptions = useVastaanottoTilaOptions({
+    haku,
+    isRekisterinpitaja: hasOphCRUD,
+  });
 
   const disabled =
     hakemukset.find(
@@ -140,11 +148,13 @@ const VastaanottoTilaDropdown = ({
 };
 
 export const ValinnanTuloksetActionBar = ({
+  haku,
   hakemukset,
   selection,
   resetSelection,
   actorRef,
 }: {
+  haku: Haku;
   hakemukset: Array<HakemuksenValinnanTulos>;
   actorRef: ValinnanTulosActorRef | SijoittelunTulosActorRef;
   selection: Set<string>;
@@ -181,6 +191,7 @@ export const ValinnanTuloksetActionBar = ({
       </Stack>
       <Stack direction="row" sx={{ alignItems: 'center', gap: 1 }}>
         <VastaanottoTilaDropdown
+          haku={haku}
           hakemukset={hakemukset}
           selection={selection}
           massStatusChangeForm={massStatusChangeForm}

--- a/src/app/haku/[oid]/hakukohde/[hakukohde]/valinnan-tulokset/components/ValinnanTuloksetSearchControls.tsx
+++ b/src/app/haku/[oid]/hakukohde/[hakukohde]/valinnan-tulokset/components/ValinnanTuloksetSearchControls.tsx
@@ -6,8 +6,10 @@ import { OphFormFieldWrapper } from '@opetushallitus/oph-design-system';
 import { SearchInput } from '@/components/search-input';
 import { useValinnanTuloksetSearchParams } from '../hooks/useValinnanTuloksetSearch';
 import { useVastaanottoTilaOptions } from '@/hooks/useVastaanottoTilaOptions';
+import { Haku } from '@/lib/kouta/kouta-types';
+import { useUserPermissions } from '@/hooks/useUserPermissions';
 
-export const ValinnanTuloksetSearchControls = () => {
+export const ValinnanTuloksetSearchControls = ({ haku }: { haku: Haku }) => {
   const {
     searchPhrase,
     setSearchPhrase,
@@ -18,6 +20,7 @@ export const ValinnanTuloksetSearchControls = () => {
   } = useValinnanTuloksetSearchParams();
 
   const { t } = useTranslations();
+  const { hasOphCRUD } = useUserPermissions();
 
   const changeValinnanTila = (e: SelectChangeEvent) => {
     setValinnanTila(e.target.value);
@@ -31,7 +34,10 @@ export const ValinnanTuloksetSearchControls = () => {
     return { value: tila as string, label: t(`sijoitteluntila.${tila}`) };
   });
 
-  const vastaanottoTilaOptions = useVastaanottoTilaOptions();
+  const vastaanottoTilaOptions = useVastaanottoTilaOptions({
+    haku,
+    isRekisterinpitaja: hasOphCRUD,
+  });
 
   return (
     <Stack

--- a/src/app/haku/[oid]/hakukohde/[hakukohde]/valinnan-tulokset/components/ValinnanTuloksetTable.tsx
+++ b/src/app/haku/[oid]/hakukohde/[hakukohde]/valinnan-tulokset/components/ValinnanTuloksetTable.tsx
@@ -218,6 +218,7 @@ export const ValinnanTuloksetTable = ({
     <>
       {!userHasOnlyReadPermission && (
         <ValinnanTuloksetActionBar
+          haku={haku}
           selection={selection}
           hakemukset={rows}
           actorRef={actorRef}

--- a/src/app/haku/[oid]/hakukohde/[hakukohde]/valinnan-tulokset/page.tsx
+++ b/src/app/haku/[oid]/hakukohde/[hakukohde]/valinnan-tulokset/page.tsx
@@ -93,7 +93,7 @@ const ValinnanTuloksetContent = ({
           alignItems: 'flex-end',
         }}
       >
-        <ValinnanTuloksetSearchControls />
+        <ValinnanTuloksetSearchControls haku={haku} />
         <PageSizeSelector pageSize={pageSize} setPageSize={setPageSize} />
       </Stack>
       <FormBox sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>

--- a/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tilat-edit-modal.tsx
+++ b/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tilat-edit-modal.tsx
@@ -31,9 +31,13 @@ import { ValinnanTulosLisatiedoilla } from '../lib/henkilo-page-types';
 import { LocalizedSelect } from '@/components/localized-select';
 import { Haku } from '@/lib/kouta/kouta-types';
 import { useIlmoittautumisTilaOptions } from '@/hooks/useIlmoittautumisTilaOptions';
-import { useVastaanottoTilaOptions } from '@/hooks/useVastaanottoTilaOptions';
+import {
+  getVastaanottoTilaLabelKey,
+  useVastaanottoTilaOptions,
+} from '@/hooks/useVastaanottoTilaOptions';
 import { useIsValintaesitysJulkaistavissa } from '@/hooks/useIsValintaesitysJulkaistavissa';
 import { refetchHakemuksenValinnanTulokset } from '@/lib/valinta-tulos-service/valinta-tulos-queries';
+import { useUserPermissions } from '@/hooks/useUserPermissions';
 
 const ModalActions = ({
   onClose,
@@ -129,7 +133,15 @@ export const ValinnanTilatEditModal = createModal<{
     () => valinnanTulos.ilmoittautumistila ?? '',
   );
 
-  const vastaanottoTilaOptions = useVastaanottoTilaOptions();
+  const { hasOphCRUD } = useUserPermissions();
+
+  const vastaanottoTilaOptions = useVastaanottoTilaOptions({
+    haku,
+    isRekisterinpitaja: hasOphCRUD,
+  });
+  const vastaanottoTilaIsSelectable = vastaanottoTilaOptions.some(
+    (option) => option.value === vastaanottoTila,
+  );
 
   const ilmoittautumisTilaOptions = useIlmoittautumisTilaOptions();
 
@@ -219,7 +231,18 @@ export const ValinnanTilatEditModal = createModal<{
             <LocalizedSelect
               sx={{ width: '100%' }}
               labelId={labelId}
-              value={vastaanottoTila}
+              value={vastaanottoTilaIsSelectable ? vastaanottoTila : ''}
+              renderValue={
+                !vastaanottoTilaIsSelectable && vastaanottoTila
+                  ? () =>
+                      t(
+                        getVastaanottoTilaLabelKey({
+                          tila: vastaanottoTila as VastaanottoTila,
+                          haku,
+                        }),
+                      )
+                  : undefined
+              }
               options={vastaanottoTilaOptions}
               onChange={(e) => setVastaanottoTila(e.target.value)}
             />

--- a/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tilat-edit-modal.tsx
+++ b/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tilat-edit-modal.tsx
@@ -32,7 +32,7 @@ import { LocalizedSelect } from '@/components/localized-select';
 import { Haku } from '@/lib/kouta/kouta-types';
 import { useIlmoittautumisTilaOptions } from '@/hooks/useIlmoittautumisTilaOptions';
 import {
-  getVastaanottoTilaLabelKey,
+  getVastaanottoTilaLabel,
   useVastaanottoTilaOptions,
 } from '@/hooks/useVastaanottoTilaOptions';
 import { useIsValintaesitysJulkaistavissa } from '@/hooks/useIsValintaesitysJulkaistavissa';
@@ -235,12 +235,11 @@ export const ValinnanTilatEditModal = createModal<{
               renderValue={
                 !vastaanottoTilaIsSelectable && vastaanottoTila
                   ? () =>
-                      t(
-                        getVastaanottoTilaLabelKey({
-                          tila: vastaanottoTila as VastaanottoTila,
-                          haku,
-                        }),
-                      )
+                      getVastaanottoTilaLabel({
+                        tila: vastaanottoTila as VastaanottoTila,
+                        haku,
+                        t,
+                      })
                   : undefined
               }
               options={vastaanottoTilaOptions}

--- a/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tulos-cells.tsx
+++ b/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tulos-cells.tsx
@@ -16,7 +16,7 @@ import { HenkilonHakukohdeTuloksilla } from '../lib/henkilo-page-types';
 import { useHaku } from '@/lib/kouta/useHaku';
 import { styled } from '@/lib/theme';
 import { LaskennanValintatapajonoTulos } from '@/hooks/useEditableValintalaskennanTulokset';
-import { getVastaanottoTilaLabelKey } from '@/hooks/useVastaanottoTilaOptions';
+import { getVastaanottoTilaLabel } from '@/hooks/useVastaanottoTilaOptions';
 
 const ValintaTableCell = styled(MuiTableCell)({
   verticalAlign: 'top',
@@ -93,12 +93,11 @@ export const ValinnanTulosCells = ({
           </ValintaTableCell>
           <ValintaTableCell>
             <div>
-              {t(
-                getVastaanottoTilaLabelKey({
-                  tila: valinnanTulos.vastaanottotila,
-                  haku,
-                }),
-              )}
+              {getVastaanottoTilaLabel({
+                tila: valinnanTulos.vastaanottotila,
+                haku,
+                t,
+              })}
             </div>
           </ValintaTableCell>
           <ValintaTableCell>

--- a/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tulos-cells.tsx
+++ b/src/app/haku/[oid]/henkilo/[hakemusOid]/components/valinnan-tulos-cells.tsx
@@ -16,6 +16,7 @@ import { HenkilonHakukohdeTuloksilla } from '../lib/henkilo-page-types';
 import { useHaku } from '@/lib/kouta/useHaku';
 import { styled } from '@/lib/theme';
 import { LaskennanValintatapajonoTulos } from '@/hooks/useEditableValintalaskennanTulokset';
+import { getVastaanottoTilaLabelKey } from '@/hooks/useVastaanottoTilaOptions';
 
 const ValintaTableCell = styled(MuiTableCell)({
   verticalAlign: 'top',
@@ -91,7 +92,14 @@ export const ValinnanTulosCells = ({
             )}
           </ValintaTableCell>
           <ValintaTableCell>
-            <div>{t(`vastaanottotila.${valinnanTulos?.vastaanottotila}`)}</div>
+            <div>
+              {t(
+                getVastaanottoTilaLabelKey({
+                  tila: valinnanTulos.vastaanottotila,
+                  haku,
+                }),
+              )}
+            </div>
           </ValintaTableCell>
           <ValintaTableCell>
             {isIlmoittautuminenPossible({

--- a/src/components/ValinnanTuloksetOtherActionsCell.tsx
+++ b/src/components/ValinnanTuloksetOtherActionsCell.tsx
@@ -64,6 +64,7 @@ export const ValinnanTuloksetOtherActionsCell = ({
 
   const showChangeHistoryForHakemus = () => {
     showModal(ChangeHistoryGlobalModal, {
+      haku,
       hakemus: {
         ...hakemus,
         valintatapajonoOid: hakemus.valintatapajonoOid ?? valintatapajonoOid,

--- a/src/components/VastaanottoTilaCell.tsx
+++ b/src/components/VastaanottoTilaCell.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/lib/sijoittelun-tulokset-utils';
 import { Haku, Hakukohde } from '@/lib/kouta/kouta-types';
 import {
-  getVastaanottoTilaLabelKey,
+  getVastaanottoTilaLabel,
   useVastaanottoTilaOptions,
 } from '@/hooks/useVastaanottoTilaOptions';
 import { useIsValintaesitysJulkaistavissa } from '@/hooks/useIsValintaesitysJulkaistavissa';
@@ -58,7 +58,11 @@ const HakijanVastaanottoTilaSection = ({
       <Typography>
         {t('sijoittelun-tulokset.hakijalle-naytetaan')}
         &nbsp;
-        {t(getVastaanottoTilaLabelKey({ tila: hakijanVastaanottoTila, haku }))}
+        {getVastaanottoTilaLabel({
+          tila: hakijanVastaanottoTila,
+          haku,
+          t,
+        })}
       </Typography>
     );
   }
@@ -116,8 +120,7 @@ const ValinnanVastaanottoTila = ({
         value={vastaanottoTilaIsSelectable ? (vastaanottoTila ?? '') : ''}
         renderValue={
           !vastaanottoTilaIsSelectable && vastaanottoTila
-            ? () =>
-                t(getVastaanottoTilaLabelKey({ tila: vastaanottoTila, haku }))
+            ? () => getVastaanottoTilaLabel({ tila: vastaanottoTila, haku, t })
             : undefined
         }
         onChange={updateVastaanottoTila}
@@ -184,7 +187,7 @@ const SijoittelunVastaanottoTila = ({
           renderValue={
             !vastaanottoTilaIsSelectable && vastaanottoTila
               ? () =>
-                  t(getVastaanottoTilaLabelKey({ tila: vastaanottoTila, haku }))
+                  getVastaanottoTilaLabel({ tila: vastaanottoTila, haku, t })
               : undefined
           }
           onChange={updateVastaanottoTila}

--- a/src/components/VastaanottoTilaCell.tsx
+++ b/src/components/VastaanottoTilaCell.tsx
@@ -13,16 +13,19 @@ import {
   isVastaanottoPossible,
 } from '@/lib/sijoittelun-tulokset-utils';
 import { Haku, Hakukohde } from '@/lib/kouta/kouta-types';
-import { useVastaanottoTilaOptions } from '@/hooks/useVastaanottoTilaOptions';
+import {
+  getVastaanottoTilaLabelKey,
+  useVastaanottoTilaOptions,
+} from '@/hooks/useVastaanottoTilaOptions';
 import { useIsValintaesitysJulkaistavissa } from '@/hooks/useIsValintaesitysJulkaistavissa';
 import { useHakijanVastaanottotila } from '@/hooks/useHakijanVastaanottotila';
 import { QuerySuspenseBoundary } from '@/components/query-suspense-boundary';
 import { ClientSpinner } from '@/components/client-spinner';
 import { isValidValinnanTila } from '@/lib/valinnan-tulokset-utils';
-import { isKorkeakouluHaku } from '@/lib/kouta/kouta-service';
 import { memo } from 'react';
 import { ValinnanTulosChangeParams } from '@/lib/state/valinnanTuloksetMachineTypes';
 import { prop } from 'remeda';
+import { useUserPermissions } from '@/hooks/useUserPermissions';
 
 const HakijanVastaanottoTilaSection = ({
   haku,
@@ -55,7 +58,7 @@ const HakijanVastaanottoTilaSection = ({
       <Typography>
         {t('sijoittelun-tulokset.hakijalle-naytetaan')}
         &nbsp;
-        {t(`vastaanottotila.${hakijanVastaanottoTila}`)}
+        {t(getVastaanottoTilaLabelKey({ tila: hakijanVastaanottoTila, haku }))}
       </Typography>
     );
   }
@@ -89,26 +92,15 @@ const ValinnanVastaanottoTila = ({
   t,
 }: Omit<VastaanOttoCellProps, 'mode' | 'valintatapajono'>) => {
   const { vastaanottoTila } = hakemus;
+  const { hasOphCRUD } = useUserPermissions();
 
-  const vastaanottotilaOptions = useVastaanottoTilaOptions((tila) => {
-    return isKorkeakouluHaku(haku)
-      ? [
-          VastaanottoTila.KESKEN,
-          VastaanottoTila.EHDOLLISESTI_VASTAANOTTANUT,
-          VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
-          VastaanottoTila.EI_VASTAANOTETTU_MAARA_AIKANA,
-          VastaanottoTila.PERUNUT,
-          VastaanottoTila.PERUUTETTU,
-          VastaanottoTila.OTTANUT_VASTAAN_TOISEN_PAIKAN,
-        ].includes(tila)
-      : [
-          VastaanottoTila.KESKEN,
-          VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
-          VastaanottoTila.EI_VASTAANOTETTU_MAARA_AIKANA,
-          VastaanottoTila.PERUNUT,
-          VastaanottoTila.PERUUTETTU,
-        ].includes(tila);
+  const vastaanottotilaOptions = useVastaanottoTilaOptions({
+    haku,
+    isRekisterinpitaja: hasOphCRUD,
   });
+  const vastaanottoTilaIsSelectable = vastaanottotilaOptions.some(
+    (option) => option.value === vastaanottoTila,
+  );
 
   const updateVastaanottoTila = (event: SelectChangeEvent<string>) => {
     updateForm({
@@ -121,7 +113,13 @@ const ValinnanVastaanottoTila = ({
     <>
       <LocalizedSelect
         ariaLabel={t('sijoittelun-tulokset.taulukko.vastaanottotieto')}
-        value={vastaanottoTila ?? ''}
+        value={vastaanottoTilaIsSelectable ? (vastaanottoTila ?? '') : ''}
+        renderValue={
+          !vastaanottoTilaIsSelectable && vastaanottoTila
+            ? () =>
+                t(getVastaanottoTilaLabelKey({ tila: vastaanottoTila, haku }))
+            : undefined
+        }
         onChange={updateVastaanottoTila}
         options={vastaanottotilaOptions}
         disabled={disabled || !isVastaanottoPossible(hakemus)}
@@ -141,8 +139,15 @@ const SijoittelunVastaanottoTila = ({
   t,
 }: Omit<VastaanOttoCellProps, 'mode'>) => {
   const { vastaanottoTila } = hakemus;
+  const { hasOphCRUD } = useUserPermissions();
 
-  const vastaanottotilaOptions = useVastaanottoTilaOptions();
+  const vastaanottotilaOptions = useVastaanottoTilaOptions({
+    haku,
+    isRekisterinpitaja: hasOphCRUD,
+  });
+  const vastaanottoTilaIsSelectable = vastaanottotilaOptions.some(
+    (option) => option.value === vastaanottoTila,
+  );
 
   const updateVastaanottoTila = (event: SelectChangeEvent<string>) => {
     updateForm({
@@ -175,7 +180,13 @@ const SijoittelunVastaanottoTila = ({
         </QuerySuspenseBoundary>
         <LocalizedSelect
           ariaLabel={t('sijoittelun-tulokset.taulukko.vastaanottotieto')}
-          value={vastaanottoTila ?? ''}
+          value={vastaanottoTilaIsSelectable ? (vastaanottoTila ?? '') : ''}
+          renderValue={
+            !vastaanottoTilaIsSelectable && vastaanottoTila
+              ? () =>
+                  t(getVastaanottoTilaLabelKey({ tila: vastaanottoTila, haku }))
+              : undefined
+          }
           onChange={updateVastaanottoTila}
           options={vastaanottotilaOptions}
           disabled={disabled}

--- a/src/components/modals/change-history-global-modal.test.tsx
+++ b/src/components/modals/change-history-global-modal.test.tsx
@@ -1,6 +1,18 @@
 import { render } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { HistoryEvent } from './change-history-global-modal';
+import { Haku, Tila } from '@/lib/kouta/kouta-types';
+import { VastaanottoTila } from '@/lib/types/sijoittelu-types';
+
+const TOISEN_ASTEEN_YHTEISHAKU: Haku = {
+  oid: 'haku-oid',
+  nimi: { fi: 'Haku' },
+  tila: Tila.JULKAISTU,
+  hakutapaKoodiUri: 'hakutapa_01',
+  hakukohteita: 1,
+  kohdejoukkoKoodiUri: 'haunkohdejoukko_11#1',
+  organisaatioOid: 'organisaatio-oid',
+};
 
 describe('HistoryEvent', () => {
   it('renders tila change correctly', () => {
@@ -42,6 +54,23 @@ describe('HistoryEvent', () => {
       'Sähköpostilähetyksen syy: sijoittelun-tulokset.muutoshistoria.muutokset.VASTAANOTTOILMOITUS' +
         'Sähköposti merkitty lähetettäväksi: 11.4.2025 16:02:01' +
         'Sähköposti lähetetty:',
+    );
+  });
+  it('renders toisen asteen vastaanottanut without sitovasti suffix', () => {
+    const VASTAANOTTOTILA_CHANGES = [
+      {
+        field: 'vastaanottotila',
+        to: VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
+      },
+    ];
+    const { container } = render(
+      <HistoryEvent
+        changes={VASTAANOTTOTILA_CHANGES}
+        haku={TOISEN_ASTEEN_YHTEISHAKU}
+      />,
+    );
+    expect(container).toHaveTextContent(
+      'sijoittelun-tulokset.muutoshistoria.muutokset.vastaanottotila: vastaanottotila.VASTAANOTTANUT',
     );
   });
 });

--- a/src/components/modals/change-history-global-modal.tsx
+++ b/src/components/modals/change-history-global-modal.tsx
@@ -25,20 +25,37 @@ import { toFormattedDateTimeString } from '@/lib/localization/translation-utils'
 import { isTimestamp } from '@/lib/time-utils';
 import { ErrorAlert } from '../error-alert';
 import { queryOptionsGetChangeHistoryForHakemus } from '@/lib/valinta-tulos-service/valinta-tulos-queries';
+import { Haku } from '@/lib/kouta/kouta-types';
+import { getVastaanottoTilaLabel } from '@/hooks/useVastaanottoTilaOptions';
+import { VastaanottoTila } from '@/lib/types/sijoittelu-types';
 
 export const HistoryEvent = ({
   changes,
+  haku,
 }: {
   changes: Array<HakemusChangeDetail>;
+  haku?: Haku;
 }) => {
   const { t } = useTranslations();
-  const parseMuutos = (muutos: string | boolean) => {
+  const parseMuutos = ({
+    field,
+    muutos,
+  }: {
+    field: string;
+    muutos: string | boolean;
+  }) => {
     if (typeof muutos === 'boolean') {
       return !muutos ? t('yleinen.ei') : t('yleinen.kylla');
     } else if (isTimestamp(muutos)) {
       return toFormattedDateTimeString(muutos);
     } else if (isEmpty(muutos)) {
       return '';
+    } else if (field === 'vastaanottotila') {
+      return getVastaanottoTilaLabel({
+        tila: muutos as VastaanottoTila,
+        haku,
+        t,
+      });
     }
 
     return t(`sijoittelun-tulokset.muutoshistoria.muutokset.${muutos}`, {
@@ -58,7 +75,7 @@ export const HistoryEvent = ({
 
   return changes.map((c, index) => (
     <Box key={`change-detail-${index}`}>
-      {parseKey(c.field)}: {parseMuutos(c.to)}
+      {parseKey(c.field)}: {parseMuutos({ field: c.field, muutos: c.to })}
     </Box>
   ));
 };
@@ -66,9 +83,11 @@ export const HistoryEvent = ({
 const HistoryModalContent = ({
   hakemusOid,
   valintatapajonoOid,
+  haku,
 }: {
   hakemusOid: string;
   valintatapajonoOid: string;
+  haku: Haku;
 }) => {
   const { data: history } = useSuspenseQuery(
     queryOptionsGetChangeHistoryForHakemus({ hakemusOid, valintatapajonoOid }),
@@ -93,7 +112,7 @@ const HistoryModalContent = ({
     makeColumnWithCustomRender<HakemusChangeEvent>({
       title: 'sijoittelun-tulokset.muutoshistoria.muutos',
       key: 'changes',
-      renderFn: (props) => <HistoryEvent changes={props.changes} />,
+      renderFn: (props) => <HistoryEvent changes={props.changes} haku={haku} />,
       sortable: false,
     }),
   ];
@@ -110,8 +129,10 @@ const HistoryModalContent = ({
 
 export const ChangeHistoryGlobalModal = createModal(
   ({
+    haku,
     hakemus,
   }: {
+    haku: Haku;
     hakemus: {
       hakemusOid: string;
       hakijanNimi: string;
@@ -148,6 +169,7 @@ export const ChangeHistoryGlobalModal = createModal(
             <HistoryModalContent
               hakemusOid={hakemus.hakemusOid}
               valintatapajonoOid={hakemus.valintatapajonoOid}
+              haku={haku}
             />
           </QuerySuspenseBoundary>
         )}

--- a/src/hooks/useVastaanottoTilaOptions.test.ts
+++ b/src/hooks/useVastaanottoTilaOptions.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from 'vitest';
 import { Haku, Tila } from '@/lib/kouta/kouta-types';
 import { VastaanottoTila } from '@/lib/types/sijoittelu-types';
 import {
+  getVastaanottoTilaLabel,
   getSelectableVastaanottoTilat,
   getVastaanottoTilaLabelKey,
 } from './useVastaanottoTilaOptions';
+import { TFunction } from '@/lib/localization/useTranslations';
 
 const HAKU_BASE: Haku = {
   oid: 'haku-oid',
@@ -101,5 +103,21 @@ describe('getVastaanottoTilaLabelKey', () => {
         },
       }),
     ).toBe('vastaanottotila.VASTAANOTTANUT_SITOVASTI');
+  });
+});
+
+describe('getVastaanottoTilaLabel', () => {
+  test('uses default value for toisen asteen vastaanottanut when localization key is missing', () => {
+    const t = ((_key: string, params?: { defaultValue?: string }) => {
+      return params?.defaultValue ?? _key;
+    }) as TFunction;
+
+    expect(
+      getVastaanottoTilaLabel({
+        tila: VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
+        haku: HAKU_BASE,
+        t,
+      }),
+    ).toBe('Vastaanottanut');
   });
 });

--- a/src/hooks/useVastaanottoTilaOptions.test.ts
+++ b/src/hooks/useVastaanottoTilaOptions.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'vitest';
+import { Haku, Tila } from '@/lib/kouta/kouta-types';
+import { VastaanottoTila } from '@/lib/types/sijoittelu-types';
+import {
+  getSelectableVastaanottoTilat,
+  getVastaanottoTilaLabelKey,
+} from './useVastaanottoTilaOptions';
+
+const HAKU_BASE: Haku = {
+  oid: 'haku-oid',
+  nimi: { fi: 'Haku' },
+  tila: Tila.JULKAISTU,
+  hakutapaKoodiUri: 'hakutapa_01',
+  hakukohteita: 1,
+  kohdejoukkoKoodiUri: 'haunkohdejoukko_11#1',
+  organisaatioOid: 'organisaatio-oid',
+};
+
+describe('getSelectableVastaanottoTilat', () => {
+  test('returns toisen asteen yhteishaku statuses for non-rekisterinpitäjä', () => {
+    expect(
+      getSelectableVastaanottoTilat({
+        haku: HAKU_BASE,
+        isRekisterinpitaja: false,
+      }),
+    ).toEqual([
+      VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
+      VastaanottoTila.EI_VASTAANOTETTU_MAARA_AIKANA,
+      VastaanottoTila.PERUNUT,
+    ]);
+  });
+
+  test('allows peruutettu for rekisterinpitäjä in toisen asteen yhteishaku', () => {
+    expect(
+      getSelectableVastaanottoTilat({
+        haku: HAKU_BASE,
+        isRekisterinpitaja: true,
+      }),
+    ).toEqual([
+      VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
+      VastaanottoTila.EI_VASTAANOTETTU_MAARA_AIKANA,
+      VastaanottoTila.PERUNUT,
+      VastaanottoTila.PERUUTETTU,
+    ]);
+  });
+
+  test('keeps korkeakouluhaku statuses unchanged', () => {
+    expect(
+      getSelectableVastaanottoTilat({
+        haku: {
+          ...HAKU_BASE,
+          kohdejoukkoKoodiUri: 'haunkohdejoukko_12#1',
+        },
+      }),
+    ).toEqual([
+      VastaanottoTila.KESKEN,
+      VastaanottoTila.EHDOLLISESTI_VASTAANOTTANUT,
+      VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
+      VastaanottoTila.EI_VASTAANOTETTU_MAARA_AIKANA,
+      VastaanottoTila.PERUNUT,
+      VastaanottoTila.PERUUTETTU,
+      VastaanottoTila.OTTANUT_VASTAAN_TOISEN_PAIKAN,
+    ]);
+  });
+
+  test('keeps other haku statuses unchanged', () => {
+    expect(
+      getSelectableVastaanottoTilat({
+        haku: {
+          ...HAKU_BASE,
+          kohdejoukkoKoodiUri: 'haunkohdejoukko_13#1',
+        },
+      }),
+    ).toEqual([
+      VastaanottoTila.KESKEN,
+      VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
+      VastaanottoTila.EI_VASTAANOTETTU_MAARA_AIKANA,
+      VastaanottoTila.PERUNUT,
+      VastaanottoTila.PERUUTETTU,
+    ]);
+  });
+});
+
+describe('getVastaanottoTilaLabelKey', () => {
+  test('uses toisen asteen label for vastaanottanut', () => {
+    expect(
+      getVastaanottoTilaLabelKey({
+        tila: VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
+        haku: HAKU_BASE,
+      }),
+    ).toBe('vastaanottotila.VASTAANOTTANUT');
+  });
+
+  test('uses default label for korkeakouluhaku vastaanottanut sitovasti', () => {
+    expect(
+      getVastaanottoTilaLabelKey({
+        tila: VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
+        haku: {
+          ...HAKU_BASE,
+          kohdejoukkoKoodiUri: 'haunkohdejoukko_12#1',
+        },
+      }),
+    ).toBe('vastaanottotila.VASTAANOTTANUT_SITOVASTI');
+  });
+});

--- a/src/hooks/useVastaanottoTilaOptions.ts
+++ b/src/hooks/useVastaanottoTilaOptions.ts
@@ -1,5 +1,8 @@
 import { VastaanottoTila } from '../lib/types/sijoittelu-types';
-import { useTranslations } from '../lib/localization/useTranslations';
+import {
+  TFunction,
+  useTranslations,
+} from '../lib/localization/useTranslations';
 import { Haku } from '@/lib/kouta/kouta-types';
 import {
   isKorkeakouluHaku,
@@ -68,6 +71,34 @@ export const getVastaanottoTilaLabelKey = ({
     ? 'vastaanottotila.VASTAANOTTANUT'
     : `vastaanottotila.${tila}`;
 
+const getVastaanottoTilaLabelDefaultValue = ({
+  tila,
+  haku,
+}: {
+  tila: VastaanottoTila;
+  haku?: Haku;
+}) =>
+  haku &&
+  isToisenAsteenYhteisHaku(haku) &&
+  tila === VastaanottoTila.VASTAANOTTANUT_SITOVASTI
+    ? 'Vastaanottanut'
+    : undefined;
+
+export const getVastaanottoTilaLabel = ({
+  tila,
+  haku,
+  t,
+}: {
+  tila: VastaanottoTila;
+  haku?: Haku;
+  t: TFunction;
+}) => {
+  const key = getVastaanottoTilaLabelKey({ tila, haku });
+  const defaultValue = getVastaanottoTilaLabelDefaultValue({ tila, haku });
+
+  return defaultValue ? t(key, { defaultValue }) : t(key);
+};
+
 type UseVastaanottoTilaOptionsConfig = {
   haku?: Haku;
   isRekisterinpitaja?: boolean;
@@ -92,6 +123,6 @@ export const useVastaanottoTilaOptions = (
     .filter(filterFn)
     .map((tila) => ({
       value: tila as string,
-      label: t(getVastaanottoTilaLabelKey({ tila, haku })),
+      label: getVastaanottoTilaLabel({ tila, haku, t }),
     }));
 };

--- a/src/hooks/useVastaanottoTilaOptions.ts
+++ b/src/hooks/useVastaanottoTilaOptions.ts
@@ -1,14 +1,97 @@
 import { VastaanottoTila } from '../lib/types/sijoittelu-types';
 import { useTranslations } from '../lib/localization/useTranslations';
+import { Haku } from '@/lib/kouta/kouta-types';
+import {
+  isKorkeakouluHaku,
+  isToisenAsteenYhteisHaku,
+} from '@/lib/kouta/kouta-service';
+
+const KORKEAKOULU_VASTAANOTTOTILAT = [
+  VastaanottoTila.KESKEN,
+  VastaanottoTila.EHDOLLISESTI_VASTAANOTTANUT,
+  VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
+  VastaanottoTila.EI_VASTAANOTETTU_MAARA_AIKANA,
+  VastaanottoTila.PERUNUT,
+  VastaanottoTila.PERUUTETTU,
+  VastaanottoTila.OTTANUT_VASTAAN_TOISEN_PAIKAN,
+];
+
+const MUUT_VASTAANOTTOTILAT = [
+  VastaanottoTila.KESKEN,
+  VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
+  VastaanottoTila.EI_VASTAANOTETTU_MAARA_AIKANA,
+  VastaanottoTila.PERUNUT,
+  VastaanottoTila.PERUUTETTU,
+];
+
+const TOISEN_ASTEEN_YHTEISHAUN_VASTAANOTTOTILAT = [
+  VastaanottoTila.VASTAANOTTANUT_SITOVASTI,
+  VastaanottoTila.EI_VASTAANOTETTU_MAARA_AIKANA,
+  VastaanottoTila.PERUNUT,
+];
+
+export const getSelectableVastaanottoTilat = ({
+  haku,
+  isRekisterinpitaja = false,
+}: {
+  haku?: Haku;
+  isRekisterinpitaja?: boolean;
+}) => {
+  if (!haku) {
+    return Object.values(VastaanottoTila);
+  }
+
+  if (isToisenAsteenYhteisHaku(haku)) {
+    return isRekisterinpitaja
+      ? [
+          ...TOISEN_ASTEEN_YHTEISHAUN_VASTAANOTTOTILAT,
+          VastaanottoTila.PERUUTETTU,
+        ]
+      : TOISEN_ASTEEN_YHTEISHAUN_VASTAANOTTOTILAT;
+  }
+
+  return isKorkeakouluHaku(haku)
+    ? KORKEAKOULU_VASTAANOTTOTILAT
+    : MUUT_VASTAANOTTOTILAT;
+};
+
+export const getVastaanottoTilaLabelKey = ({
+  tila,
+  haku,
+}: {
+  tila: VastaanottoTila;
+  haku?: Haku;
+}) =>
+  haku &&
+  isToisenAsteenYhteisHaku(haku) &&
+  tila === VastaanottoTila.VASTAANOTTANUT_SITOVASTI
+    ? 'vastaanottotila.VASTAANOTTANUT'
+    : `vastaanottotila.${tila}`;
+
+type UseVastaanottoTilaOptionsConfig = {
+  haku?: Haku;
+  isRekisterinpitaja?: boolean;
+  filterFn?: (tila: VastaanottoTila) => boolean;
+};
 
 export const useVastaanottoTilaOptions = (
-  filterFn: (tila: VastaanottoTila) => boolean = () => true,
+  configOrFilterFn:
+    | UseVastaanottoTilaOptionsConfig
+    | ((tila: VastaanottoTila) => boolean) = {},
 ) => {
   const { t } = useTranslations();
-  return Object.values(VastaanottoTila)
+
+  const config =
+    typeof configOrFilterFn === 'function'
+      ? { filterFn: configOrFilterFn }
+      : configOrFilterFn;
+
+  const { haku, isRekisterinpitaja, filterFn = () => true } = config;
+
+  return getSelectableVastaanottoTilat({ haku, isRekisterinpitaja })
     .filter(filterFn)
     .map((tila) => ({
       value: tila as string,
-      label: t(`vastaanottotila.${tila}`),
+      label: t(getVastaanottoTilaLabelKey({ tila, haku })),
     }));
 };

--- a/src/lib/localization/messages/fi.json
+++ b/src/lib/localization/messages/fi.json
@@ -498,6 +498,7 @@
   "vastaanottotila": {
     "KESKEN": "Kesken",
     "EHDOLLISESTI_VASTAANOTTANUT": "Ehdollisesti vastaanottanut",
+    "VASTAANOTTANUT": "Vastaanottanut",
     "VASTAANOTTANUT_SITOVASTI": "Vastaanottanut sitovasti",
     "EI_VASTAANOTETTU_MAARA_AIKANA": "Ei vastaanotettu määräaikana",
     "PERUNUT": "Perunut",


### PR DESCRIPTION
Rajataan kohdejoukon 11 vastaanottotilavalinnat toisen asteen tiloihin ja sallitaan Peruutettu vain rekisterinpitäjälle

Oletko lisännyt tarvittavat yksikkö- tai ui-testit toiminnallisuudelle? Kyllä/En
Oletko tarkistanut ja päivittänyt riippuvuudet? Kyllä/En
Oletko kokeillut toimiiko käyttöliittymä mobiilissa landscape moodissa? Kyllä/En/Ei koske
Oletko testannut että lisäämäsi toiminto on saavutettava? Kyllä/En/Ei koske
